### PR TITLE
fix loading a fursuit as performer

### DIFF
--- a/src/lib/mkpp3_core.ts
+++ b/src/lib/mkpp3_core.ts
@@ -8,11 +8,11 @@ import { promisify } from "util";
 
 
 
-function resolvePerformer(ds: DataSource, performer: string | Performer): Promise<Performer>{
+async function resolvePerformer(ds: DataSource, performer: string | Performer): Promise<Performer>{
     if (typeof performer === "string"){
-        return ds.loadPerformer(performer) || ds.loadCharacter(performer);
+        return await ds.loadPerformer(performer) || await ds.loadCharacter(performer);
     } else {
-        return new Promise((resolve) => { resolve(performer) });
+        return performer;
     }
 }
 
@@ -264,7 +264,7 @@ async function init() {
                 }
 
             }
-            return { ds, readConfig, conv, resolveCharacter, convAndWrite, readProfileScript, writeProfilesFromScript };
+            return { ds, readConfig, conv, resolveCharacter, convAndWrite, readProfileScript, writeProfilesFromScript, resolvePerformer };
         }(ds, config.profilePath);
     } catch (error) {
         throw error;


### PR DESCRIPTION
A fursuit can have another fursuit listed as its performer. This is used
when the second fursuit represents someone's main fursona, and the first
is an additional character they portray.

When a entity like this was encountered, the program was returning null
as the performer, while the intended fallback is to use the name specified.

The intended logic in `resolvePerformer` checks if the result of
`loadPerformer` is _falsy_, then falls back to `loadCharacter`. However,
`loadPerformer` is an async function, and `resolvePerformer` wasn't awaiting
on it; thus it was checking whether the returned Promise is _falsy_, which
is never true.

This commit fixes loading fursuits as performers by awaiting on
`loadPerformer`, thus only falling back if the unwrapped value is _falsy_.

fixes GH-1.